### PR TITLE
投稿にタグの枠を追加 複数にも対応 #20

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,6 +21,11 @@ class ProductsController < ApplicationController
     end
 
     if @product.save
+      # タグの保存処理
+      if params[:product][:tag_names]
+        tag_names = params[:product][:tag_names].split(",").map(&:strip).uniq
+        @product.tags = tag_names.map { |name| Tag.find_or_initialize_by(name:) }
+      end
       redirect_to products_path, notice: "商品が登録されました。"
     else
       # エラー時はレビューオブジェクトを再構築（userも設定）
@@ -40,7 +45,7 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(
       :name, :category, :image,
-      review_attributes: [ :richness, :bitterness, :sweetness, :aftertaste, :appearance, :score, :comment, :taste_level, :user_id ]
+      review_attributes: [ :richness, :bitterness, :sweetness, :aftertaste, :appearance, :score, :comment, :taste_level, :user_id, :tag_names ]
     )
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,11 +1,20 @@
 class Product < ApplicationRecord
   belongs_to :user
-
   # ActiveStorageで画像添付
   has_one_attached :image
   # 追記
   has_one :review, dependent: :destroy
   accepts_nested_attributes_for :review
+
+  # タグの関連付け
+  has_many :taggings, dependent: :destroy
+  has_many :tags, through: :taggings
+  attr_accessor :tag_names
+
+  # 保存時にタグの関連を更新
+  after_save :assign_tags
+
+
   # タグ付け
   enum :category, { latte: 0, espresso: 1, matcha: 2, tea: 3 }
 
@@ -20,5 +29,17 @@ class Product < ApplicationRecord
   def average_score
     return 0.0 if review.nil?
     review.score || 0.0
+  end
+
+  private
+
+  def assign_tags
+    return if tag_names.blank?
+
+    tag_list = tag_names.split(",").map(&:strip).uniq
+
+    self.tags = tag_list.map do |name|
+      Tag.find_or_create_by(name: name)
+    end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,4 @@
 class Tag < ApplicationRecord
+    has_many :taggings, dependent: :destroy
+    has_many :products, through: :taggings
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,4 @@
+class Tagging < ApplicationRecord
+  belongs_to :product
+  belongs_to :tag
+end

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -52,6 +52,11 @@
     </div>
 
     <div class="form-control">
+      <%= f.label :tag_names, "タグ（カンマ区切り）", class: "label" %>
+      <%= f.text_field :tag_names, value: @product.tag_names, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control">
       <%= f.label :image, "画像", class: "label" %>
       <%= f.file_field :image, class: "file-input file-input-bordered w-full" %>
     </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -9,6 +9,15 @@
     <% if @product.image.attached? %>
       <%= image_tag @product.image, class: "w-full max-w-md object-cover mb-4" %>
     <% end %>
+
+    <% if @product.tags.present? %>
+      <p class="text-gray-600 mb-2">
+        タグ:
+        <% @product.tags.each do |tag| %>
+          <span class="badge badge-outline mr-1"><%= tag.name %></span>
+        <% end %>
+      </p>
+    <% end %>
   </div>
 
   <!-- レビュー情報 -->

--- a/db/migrate/20250805133253_create_taggings.rb
+++ b/db/migrate/20250805133253_create_taggings.rb
@@ -1,0 +1,10 @@
+class CreateTaggings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :taggings do |t|
+      t.references :product, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_03_135738) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_05_133253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_03_135738) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_taggings_on_product_id"
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -112,4 +121,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_03_135738) do
   add_foreign_key "products", "users"
   add_foreign_key "reviews", "products"
   add_foreign_key "reviews", "users"
+  add_foreign_key "taggings", "products"
+  add_foreign_key "taggings", "tags"
 end

--- a/test/fixtures/taggings.yml
+++ b/test/fixtures/taggings.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  product: one
+  tag: one
+
+two:
+  product: two
+  tag: two

--- a/test/models/tagging_test.rb
+++ b/test/models/tagging_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TaggingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
タグを商品に付与できる機能を追加する。

## 実装内容
- タグ入力欄をフォームに追加
- tags はカンマ区切りで複数対応

## 関連Issue
Closes #20