### PR TITLE
投稿の編集と削除機能の追加 #23

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,8 @@
 class ProductsController < ApplicationController
   # ログインページへリダイレクト
-  before_action :authenticate_user!, only: [ :new, :create ]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_product, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_user!, only: [:edit, :update, :destroy]
 
   def index
     @q = Product.ransack(params[:q])
@@ -14,18 +16,11 @@ class ProductsController < ApplicationController
 
   def create
     @product = current_user.products.build(product_params)
-
-    # Reviewにuserを明示的に設定
-    if @product.review
-      @product.review.user = current_user
-    end
+    @product.review.user = current_user if @product.review
 
     if @product.save
       # タグの保存処理
-      if params[:product][:tag_names]
-        tag_names = params[:product][:tag_names].split(",").map(&:strip).uniq
-        @product.tags = tag_names.map { |name| Tag.find_or_initialize_by(name:) }
-      end
+      save_tags
       redirect_to products_path, notice: "商品が登録されました。"
     else
       # エラー時はレビューオブジェクトを再構築（userも設定）
@@ -36,8 +31,25 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
     @review = @product.review  # 単数形に変更
+  end
+
+  def edit
+  end
+
+  def update
+    if @product.update(product_params)
+      save_tags
+      redirect_to product_path(@product), notice: "投稿を更新しました。"
+    else
+      flash.now[:alert] = "更新に失敗しました。"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @product.destroy
+    redirect_to products_path, notice: "投稿を削除しました。"
   end
 
   private
@@ -45,7 +57,21 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(
       :name, :category, :image,
-      review_attributes: [ :richness, :bitterness, :sweetness, :aftertaste, :appearance, :score, :comment, :taste_level, :user_id, :tag_names ]
+      review_attributes: [:id, :richness, :bitterness, :sweetness, :aftertaste, :appearance, :score, :comment, :taste_level]
     )
+  end
+  def set_product
+    @product = Product.find(params[:id])
+  end
+
+  def authorize_user!
+    redirect_to products_path, alert: "権限がありません。" unless @product.user == current_user
+  end
+
+  def save_tags
+    if params[:product][:tag_names]
+      tag_names = params[:product][:tag_names].split(",").map(&:strip).uniq
+      @product.tags = tag_names.map { |name| Tag.find_or_initialize_by(name:) }
+    end
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,8 +1,8 @@
 class ProductsController < ApplicationController
   # ログインページへリダイレクト
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_product, only: [:show, :edit, :update, :destroy]
-  before_action :authorize_user!, only: [:edit, :update, :destroy]
+  before_action :authenticate_user!, only: [ :new, :create, :edit, :update, :destroy ]
+  before_action :set_product, only: [ :show, :edit, :update, :destroy ]
+  before_action :authorize_user!, only: [ :edit, :update, :destroy ]
 
   def index
     @q = Product.ransack(params[:q])
@@ -57,7 +57,7 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(
       :name, :category, :image,
-      review_attributes: [:id, :richness, :bitterness, :sweetness, :aftertaste, :appearance, :score, :comment, :taste_level]
+      review_attributes: [ :id, :richness, :bitterness, :sweetness, :aftertaste, :appearance, :score, :comment, :taste_level ]
     )
   end
   def set_product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -21,6 +21,11 @@ class Product < ApplicationRecord
   validates :name, presence: true
   validates :category, presence: true
 
+  # タグ名を取得するメソッド
+  def tag_names
+    tags.pluck(:name).join(', ')
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     %w[name category created_at updated_at]
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -23,7 +23,7 @@ class Product < ApplicationRecord
 
   # タグ名を取得するメソッド
   def tag_names
-    tags.pluck(:name).join(', ')
+    tags.pluck(:name).join(", ")
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,0 +1,126 @@
+<!-- 編集ページ -->
+<h1 class="text-2xl font-bold mb-4">商品を編集する</h1>
+
+<!-- ステップバー -->
+<div class="max-w-2xl w-full mx-auto px-4">
+  <div class="bg-gray-200 rounded-full h-2.5 mb-2">
+    <div id="progress-bar" class="bg-primary h-2.5 rounded-full transition-all duration-300 ease-in-out" style="width: 0%;"></div>
+  </div>
+
+<!-- ステップ名 -->
+<div class="flex justify-between max-w-2xl mx-auto mb-8 px-4" id="step-labels">
+  <% steps = [
+    { number: 1, label: "商品情報", description: "商品名・店舗名を入力" },
+    { number: 2, label: "味覚評価", description: "5段階で評価" },
+    { number: 3, label: "コメント", description: "自由に感想を書く" }
+  ] %>
+
+  <% steps.each_with_index do |step, index| %>
+    <div class="flex flex-col items-center w-1/3">
+      <!-- ステップ番号アイコン -->
+      <div id="step-circle-<%= index + 1 %>" class="w-8 h-8 rounded-full border-2 border-primary text-primary flex items-center justify-center mb-2 font-bold">
+        <%= step[:number] %>
+      </div>
+      <div class="text-sm font-semibold text-gray-800"><%= step[:label] %></div>
+      <div class="text-xs text-gray-500 text-center mt-1"><%= step[:description] %></div>
+    </div>
+  <% end %>
+</div>
+
+<%= form_with model: @product, local: true, class: "space-y-4" do |f| %>
+  <% if @product.errors.any? %>
+    <div class="alert alert-error">
+      <ul>
+        <% @product.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <!-- ステップ1: 商品情報 -->
+<div class="max-w-xl mx-auto card bg-white shadow-md p-6 rounded-xl">
+  <div id="step-1" class="step-panel" data-step="1">
+    <div class="form-control">
+      <%= f.label :name, "商品名", class: "label" %>
+      <%= f.text_field :name, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control">
+      <%= f.label :category, "カテゴリ", class: "label" %>
+      <%= f.select :category, Product.categories.keys.map { |k| [k.titleize, k] }, {}, class: "select select-bordered w-full" %>
+    </div>
+
+    <div class="form-control">
+      <%= f.label :tag_names, "タグ（カンマ区切り）", class: "label" %>
+      <%= f.text_field :tag_names, value: @product.tag_names, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control">
+      <%= f.label :image, "画像", class: "label" %>
+      <% if @product.image.attached? %>
+        <div class="mb-2">
+          <p class="text-sm text-gray-600">現在の画像:</p>
+          <%= image_tag @product.image, class: "w-32 h-32 object-cover rounded mb-2" %>
+        </div>
+      <% end %>
+      <%= f.file_field :image, class: "file-input file-input-bordered w-full" %>
+      <p class="text-xs text-gray-500 mt-1">※新しい画像を選択すると現在の画像が置き換えられます</p>
+    </div>
+
+    <div class="flex justify-end mt-4">
+      <button type="button" class="next-button btn btn-primary mt-4">次へ</button>
+    </div>
+  </div>
+
+<!-- ステップ2 & 3: レビュー入力 + コメント -->
+<%= f.fields_for :review, (@product.review || @product.build_review) do |rf| %>
+  <!-- ステップ2: 味覚評価 -->
+  <div id="step-2" class="step-panel hidden" data-step="2">
+    <div class="divider">レビュー情報</div>
+    <% [
+      ["濃さ（🍵）", :richness, "🍵"],
+      ["苦味（☕）", :bitterness, "☕"],
+      ["甘さ（🍬）", :sweetness, "🍬"],
+      ["後味（🎐）", :aftertaste, "🎐"],
+      ["見た目（👀）", :appearance, "👀"],
+      ["総合評価（★）", :score, "★"]
+    ].each do |label, name, symbol| %>
+      <div class="form-control mb-4" data-controller="stars" data-stars-name="product[review_attributes][<%= name %>]" data-stars-symbol="<%= symbol %>">
+        <label class="label"><%= label %></label>
+        <div class="flex space-x-1">
+          <% 5.times do |i| %>
+            <i class="star cursor-pointer text-2xl text-gray-400" data-action="click->stars#select" data-value="<%= i + 1 %>"><%= symbol %></i>
+          <% end %>
+        </div>
+        <%= rf.hidden_field name, data: { stars_target: "input" } %>
+      </div>
+    <% end %>
+
+    <!-- ステップ2のナビゲーション -->
+    <div class="flex justify-between mt-4">
+      <button type="button" class="prev-button btn btn-secondary">戻る</button>
+      <button type="button" class="next-button btn btn-primary">次へ</button>
+    </div>
+  </div>
+
+  <!-- ステップ3: コメント -->
+  <div id="step-3" class="step-panel hidden" data-step="3">
+    <div class="form-control">
+      <%= rf.label :comment, "コメント", class: "label" %>
+      <%= rf.text_area :comment, class: "textarea textarea-bordered w-full" %>
+    </div>
+
+    <!-- ステップ3のナビゲーション -->
+    <div class="flex justify-between mt-4">
+      <button type="button" class="prev-button btn btn-secondary">戻る</button>
+      <div class="flex space-x-2">
+        <%= link_to "キャンセル", product_path(@product), class: "btn btn-outline" %>
+        <%= f.submit "商品を更新する", class: "btn btn-primary" %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+  <% end %>
+</div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,6 +4,14 @@
   <!-- 商品情報 -->
   <h1 class="text-2xl font-bold">商品詳細</h1>
   <div class="card bg-base-100 shadow p-4">
+
+    <% if user_signed_in? && @product.user == current_user %>
+      <div class="absolute top-4 right-4 flex space-x-2">
+        <%= link_to "編集", edit_product_path(@product), class: "btn btn-sm btn-outline btn-primary" %>
+        <%= link_to "削除", product_path(@product), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-sm btn-outline btn-error" %>
+      </div>
+    <% end %>
+
     <h1 class="text-3xl font-bold mb-4"><%= @product.name %></h1>
     <p class="text-gray-600 mb-2">カテゴリ: <%= @product.category.titleize %></p>
     <% if @product.image.attached? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get "homes/top"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :products, only: [ :index, :show, :new, :create ]
+  resources :products, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
   # Topページ
   root "homes#top"
 


### PR DESCRIPTION
## 概要
レビュー付き商品投稿を編集・削除できる機能を作成する。

## 実装内容
- 投稿フォームを再利用して編集機能作成
- 削除機能
投稿者以外は編集/削除不可に制御

## 関連Issue
Closes #23