### PR TITLE
Google アナリティクス（GA4）導入#164

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,19 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <!-- Google Analytics (GA4) -->
+    <% if Rails.env.production? %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_MEASUREMENT_ID'] %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '<%= ENV['GA_MEASUREMENT_ID'] %>', {
+          'anonymize_ip': true
+        });
+      </script>
+    <% end %>
+
     <!-- Font Awesome CDN -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 


### PR DESCRIPTION
## 概要
Matcha Tasty に Google アナリティクス（GA4）を導入し、ユーザー行動データ（PV、遷移、投稿率、離脱ポイントなど）を計測可能にする。今後の分析・改善に役立てるため、初期設定からイベント計測の基盤を整備する。

## 実装内容
- Google Analytics プロパティを作成（GA4）
- Webストリーム ID / Measurement ID（G-XXXX）を取得
- データ収集有効化・IP 匿名化設定

## 関連Issue
Closes #164 